### PR TITLE
Read token from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,5 @@ Here's the currently supported options
         frequency at which usage data is refreshed (default 30m0s)
 ```
 
-A docker image will be released soon.
+The exporter reads the auth token either from the -github-auth-token flag or the `GITHUB_TOKEN` environment variable.
+

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -49,6 +49,10 @@ func run() int {
 		zap.String("listen_address", listenAddress),
 	)
 
+	if githubAuthToken == "" {
+		githubAuthToken = os.Getenv("GITHUB_TOKEN")
+	}
+
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 


### PR DESCRIPTION
### What Does This PR do?

This PR makes the exporter try to read the token from an environment variable is the token flag is empty.