### PR TITLE
Disregard concurency

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ go run ./cmd/exporter -help
 Here's the currently supported options
 
 ```
--concurency int
-    How many requests are allowed in parallel (default 100)
 -github-auth-token string
     GitHub auth token
 -listen-address string
@@ -97,4 +95,3 @@ Here's the currently supported options
 ```
 
 The exporter reads the auth token either from the -github-auth-token flag or the `GITHUB_TOKEN` environment variable.
-

--- a/actions/collector_test.go
+++ b/actions/collector_test.go
@@ -168,7 +168,6 @@ github_actions_workflow_active_repos 3
 				logger  = zaptest.NewLogger(t)
 				gh      = github.NewClient(mock.NewMockedHTTPClient(testCase.mockOptions...))
 				fetcher = actions.NewOrgUsageFetcher(
-					100,
 					24*time.Hour,
 					"totocorp",
 					gh,

--- a/actions/usage.go
+++ b/actions/usage.go
@@ -33,18 +33,16 @@ type OrgUsageFetcher struct {
 	gh     *github.Client
 	logger *zap.Logger
 
-	concurencyLimit int
-	maxLastPushed   time.Duration
-	org             string
+	maxLastPushed time.Duration
+	org           string
 }
 
-func NewOrgUsageFetcher(concurencyLimit int, maxLastPushed time.Duration, org string, gh *github.Client, logger *zap.Logger) *OrgUsageFetcher {
+func NewOrgUsageFetcher(maxLastPushed time.Duration, org string, gh *github.Client, logger *zap.Logger) *OrgUsageFetcher {
 	return &OrgUsageFetcher{
-		concurencyLimit: concurencyLimit,
-		maxLastPushed:   maxLastPushed,
-		org:             org,
-		gh:              gh,
-		logger:          logger,
+		maxLastPushed: maxLastPushed,
+		org:           org,
+		gh:            gh,
+		logger:        logger,
 	}
 }
 
@@ -55,8 +53,6 @@ func (f *OrgUsageFetcher) Fetch(ctx context.Context) (*Usage, error) {
 
 		group, groupCtx = errgroup.WithContext(ctx)
 	)
-
-	group.SetLimit(f.concurencyLimit)
 
 	group.Go(func() error {
 		return scanAllOrgRepos(

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -27,7 +27,6 @@ func run() int {
 		listenAddress   string
 		githubAuthToken string
 		organization    string
-		concurencyLimit int
 		enablePprof     bool
 		maxLastPushed   time.Duration
 		refreshPeriod   time.Duration
@@ -36,7 +35,6 @@ func run() int {
 
 	flag.StringVar(&githubAuthToken, "github-auth-token", "", "GitHub auth token")
 	flag.StringVar(&organization, "organization", "", "Organization to monitor")
-	flag.IntVar(&concurencyLimit, "concurency", 100, "How many requests are allowed in parallel")
 	flag.DurationVar(&maxLastPushed, "max-last-pushed", 35*24*time.Hour, "How many time since the last push to consider a repo inactive")
 	flag.DurationVar(&refreshPeriod, "refresh-period", 30*time.Minute, "Frequency at which usage data is refreshed")
 	flag.DurationVar(&shutdownDelay, "shutdown-delay", 15*time.Second, "Graceful shutdown delay")
@@ -49,7 +47,6 @@ func run() int {
 	logger.Info(
 		"Starting exporter",
 		zap.String("organization", organization),
-		zap.Int("concurrency", concurencyLimit),
 		zap.Duration("max_last_pushed", maxLastPushed),
 		zap.Duration("refresh_period", refreshPeriod),
 		zap.String("listen_address", listenAddress),
@@ -70,7 +67,6 @@ func run() int {
 	}
 
 	fetcher := actions.NewOrgUsageFetcher(
-		concurencyLimit,
 		maxLastPushed,
 		organization,
 		gh,

--- a/cmd/print/main.go
+++ b/cmd/print/main.go
@@ -20,13 +20,11 @@ func run() int {
 	var (
 		githubAuthToken string
 		organization    string
-		concurencyLimit int
 		maxLastPushed   time.Duration
 	)
 
 	flag.StringVar(&githubAuthToken, "github-auth-token", "", "GitHub auth token")
 	flag.StringVar(&organization, "organization", "", "organization")
-	flag.IntVar(&concurencyLimit, "concurency", 100, "How many request are allowed in parallel")
 	flag.DurationVar(&maxLastPushed, "max-last-pushed", 30*24*time.Hour, "How many time since the last push to consider a repo inactive")
 	flag.Parse()
 
@@ -47,7 +45,6 @@ func run() int {
 	}
 
 	fetcher := actions.NewOrgUsageFetcher(
-		concurencyLimit,
 		maxLastPushed,
 		organization,
 		gh,

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -22,7 +22,8 @@ func NewClient(ctx context.Context, token string, logger *zap.Logger) (*github.C
 			func(ctx *github_ratelimit.CallbackContext) {
 				logger.Error(
 					"Detected ratelimit, all calls are currently held",
-					zap.Any("context", ctx),
+					zap.Any("sleep-until", ctx.SleepUntil),
+					zap.Any("total-sleep-time", ctx.TotalSleepTime),
 				)
 			},
 		),


### PR DESCRIPTION
### What Does This PR do?

If we set concurency to low this can create a deadlock. Now that the ratelimiter is working properly, this is redundant. So let's get rid of it.

This PR also fixes the log output when a rate limit happens.
